### PR TITLE
Corrected CORS configuration option

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var app = express();
 // enable CORS (https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
 // so that your API is remotely testable by FCC 
 var cors = require('cors');
-app.use(cors({optionSuccessStatus: 200}));  // some legacy browsers choke on 204
+app.use(cors({optionsSuccessStatus: 200}));  // some legacy browsers choke on 204
 
 // http://expressjs.com/en/starter/static-files.html
 app.use(express.static('public'));


### PR DESCRIPTION
As per https://github.com/freeCodeCamp/boilerplate-project-timestamp/pull/42

CORS config was missing a letter. "option**s**SuccessStatus"