### PR TITLE
fix: add dotenv package for environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,11 @@
 				"ms": "2.0.0"
 			}
 		},
+		"dotenv": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 	},
 	"dependencies": {
 		"express": "^5.0.0-alpha.2",
-		"cors": "^2.8.1"
+		"cors": "^2.8.1",
+		"dotenv": "^8.2.0"
 	},
 	"repository": {
 		"type": "git",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 // where your node app starts
 
 // init project
+require('dotenv').config();
 var express = require('express');
 var app = express();
 


### PR DESCRIPTION
Since the project is using .env file for fetching the port, it had no `dotenv` dependency. This creates confusion when `process.env.PORT` doesn't work. I hope this is convenient for beginners :+1:

Related to: https://github.com/freeCodeCamp/freeCodeCamp/issues/39825